### PR TITLE
Edited development build command for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack src/js/app.js dist/bundle.js",
+    "build": "webpack src/js/app.js --output dist/bundle.js --mode development",
     "build:prod": "webpack src/js/app.js dist/bundle.js -p"
   },
   "author": "",


### PR DESCRIPTION
Edited development build command for webpack, to resolve following  error 

"Module not found: Error: Can't resolve 'dist/bundle.js'
WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior."